### PR TITLE
closes #36 Set daily cront tasks

### DIFF
--- a/app/tasks/DailyImageTask.scala
+++ b/app/tasks/DailyImageTask.scala
@@ -4,6 +4,14 @@ import play.api._
 import models.{ GoogleSearchResultDownloader, DailySearchRequest }
 import akka.actor._
 
+// How to run this task:
+// in development:
+// $ activator "run-main tasks.DailyImageTask"
+// in production:
+// $ cd ayanerer-1.0-SNAPSHOT
+// $ bin/ayanerer -main tasks.DailyImageTask -Dconfig.file=./conf/prod.conf
+
+
 object DailyImageTask extends App with Task {
   def task(app: Application) = {
     getImages(app, "佐倉綾音")

--- a/app/tasks/DailyImageTask.scala
+++ b/app/tasks/DailyImageTask.scala
@@ -4,7 +4,7 @@ import play.api._
 import models.{ GoogleSearchResultDownloader, DailySearchRequest }
 import akka.actor._
 
-class DailyImageTask extends Task {
+object DailyImageTask extends App with Task {
   def task(app: Application) = {
     getImages(app, "佐倉綾音")
   }

--- a/app/tasks/SeedImageTask.scala
+++ b/app/tasks/SeedImageTask.scala
@@ -4,7 +4,7 @@ import play.api._
 import models.{ GoogleSearchResultDownloader, SeedSearchRequest }
 import akka.actor._
 
-class SeedImageTask extends Task {
+object SeedImageTask extends Task {
   def task(app: Application) = {
     getImages(app, "佐倉綾音")
   }

--- a/app/tasks/Task.scala
+++ b/app/tasks/Task.scala
@@ -15,10 +15,9 @@ trait Task extends Runnable {
   def task(app: Application)
 
   def environment(): Mode.Mode = {
-    sys.env("PLAY_ENV") match {
-      case "development" => Mode.Dev
-      case "production" => Mode.Prod
-      case "test" => Mode.Test
+    System.getProperty("play.mode") match {
+      case "Prod" => Mode.Prod
+      case _ => Mode.Dev
     }
   }
 

--- a/app/tasks/Task.scala
+++ b/app/tasks/Task.scala
@@ -3,6 +3,8 @@ package tasks
 import play.api._
 
 trait Task extends Runnable {
+  run()
+
   final def run() {
     val app = application()
     try {

--- a/build.sbt
+++ b/build.sbt
@@ -6,8 +6,6 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
   .settings(
-    registerTask("seed-image-download", "tasks.SeedImageTask", "image from google"),
-    registerTask("daily-image-download", "tasks.DailyImageTask", "image from google"),
     javaOptions in Test += "-Dconfig.file=conf/test.conf"
   )
 
@@ -29,18 +27,3 @@ libraryDependencies ++= Seq(
 )
 
 resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"
-
-
-def registerTask(name: String, taskClass: String, description: String) = {
-  val sbtTask = (dependencyClasspath in Runtime) map { (deps) =>
-    val depURLs = deps.map(_.data.toURI.toURL).toArray
-    val classLoader = new URLClassLoader(depURLs, null)
-    val task = classLoader.
-                 loadClass(taskClass).
-                 newInstance().
-                 asInstanceOf[Runnable]
-    task.run()
-  }
-  TaskKey[Unit](name, description) <<= sbtTask.dependsOn(compile in Compile)
-}
-


### PR DESCRIPTION
I fix task definition to execute in production.

If you run a task in development:
```bash
$ activator "run-main tasks.DailyImageTask"
```

or, if you run a task in production:
```bash
$ cd ayanerer-1.0-SNAPSHOT
$ bin/ayanerer -main tasks.DailyImageTask -Dconfig.file=./conf/prod.conf
```